### PR TITLE
Add ca-certificates to devcontainer-nodejs

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -2,7 +2,8 @@
 FROM node:lts-slim AS devcontainer-nodejs
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update -y && \
-	apt-get install -y --no-install-recommends git bzip2 && \
+	apt-get install -y --no-install-recommends git bzip2 ca-certificates && \
+	update-ca-certificates && \
 	apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 
 USER node


### PR DESCRIPTION
Missing `ca-certificates` package causes any packages embedded with `git clone` to fail during `yarn install`