### PR TITLE
Add ps as dependency for web-dev-server

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -2,7 +2,7 @@
 FROM node:lts-slim AS devcontainer-nodejs
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update -y && \
-	apt-get install -y --no-install-recommends git bzip2 ca-certificates && \
+	apt-get install -y --no-install-recommends git bzip2 procps ca-certificates && \
 	update-ca-certificates && \
 	apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
* Interrupting `yarn run haxsite` with **CTRL + C** currently results in a bunch of warnings since `ps` isn't included in the base slim image
    * The command uses `web-dev-server`, Node depends on `ps` for deduplicating processes