### PR TITLE
Refactored for ARM support with Docker/GitHub-Builder action

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,62 +1,43 @@
-name: Publish HAXTheWeb to ghcr.io
+name: Publish HAXTheWeb images to ghcr.io
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
-  Push-HAX-Containers:
+  build-and-push:
     if: github.repository_owner == 'haxtheweb'
-    
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
+
     strategy:
       matrix:
-        include:
-          - target: devcontainer-nodejs
+        target: [
+          devcontainer-nodejs
+          ]
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
+    with:
+      output: image
+      push: true
+      context: .
+      file: ./images/Containerfile
+      target: ${{ matrix.target }}
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}
+      set-meta-labels: true
+      meta-tags: |
+        type=ref,event=branch
+        type=semver,pattern={{version}}
+        type=sha,prefix=sha-
+        type=raw,value=latest,enable={{is_default_branch}}
+      cache: true
+      cache-scope: ${{ matrix.target }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for container
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./images/Containerfile
-          target: ${{ matrix.target }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
-      
-      - name: Generate artifact attestation
-        uses: actions/attest@v4
-        with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true


### PR DESCRIPTION
## New Features
* Add support for `arm64` architecture in our container definitions
    * By default, Dev Containers and Docker Desktop try to pull an `arm64` image on macOS and Windows ARM. Since we didn't have this definition, users got time out errors and needed to manually pull an `amd64` image 
    * `amd64` containers are slower on macOS and Windows ARM since the architecture needs to be emulated.
* Migrated our `publish-ghcr.io` GitHub Action to the `Docker/GitHub-Builder` template
    * This template follows best practices while reducing the maintenance burden for our contributors

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2643